### PR TITLE
fix: confirm page title and subtitle size, image position and text color

### DIFF
--- a/src/components/Text.jsx
+++ b/src/components/Text.jsx
@@ -136,10 +136,19 @@ const Text =
   ${
   /** @param {TextProps} props */
   props =>
+      props.medium &&
+      css`
+        ${text['500']};
+      `}
+      
+  ${
+  /** @param {TextProps} props */
+  props =>
       props.bold &&
       css`
         ${text['600']};
       `}
+
   
   //Colors
   ${

--- a/src/components/Text.jsx
+++ b/src/components/Text.jsx
@@ -148,7 +148,6 @@ const Text =
       css`
         ${text['600']};
       `}
-
   
   //Colors
   ${

--- a/src/pages/Confirm/Confirm.layout.jsx
+++ b/src/pages/Confirm/Confirm.layout.jsx
@@ -13,10 +13,10 @@ const Confirm = ({ headerTitle, headerSubTitle, children, RatingModal, FinalModa
         <BackButton />
       </BackButtonContainer>  
       <HeaderContainer>
-        <Text as="h1" title>
+        <Text as="h1" title xlarge>
           {headerTitle}
         </Text>
-        <Text subtitle >{headerSubTitle}</Text>
+        <Text subtitle medium xlg>{headerSubTitle}</Text>
         <CheckImg src={note} alt="Note icon" />
       </HeaderContainer>
     </Header>

--- a/src/pages/Confirm/Confirm.styled.jsx
+++ b/src/pages/Confirm/Confirm.styled.jsx
@@ -31,21 +31,24 @@ export const CheckImg = styled.img`
 
   @media (min-width: 961px) {
     width: 80px;
-    height: auto;
   }
 
   @media (min-width: 1025px) {
     position: absolute;
     right: 0;
-    bottom: 25%;
-    width: 147px;
+    bottom: 0;
+    width: 320px;
   }
 `
 
 export const HeaderContainer = styled.div`
   position: relative;
-  margin: 5vw;
+  margin: 120px 5vw 80px;
   height: 100%;
+
+  @media (min-width: 1025px) {
+    white-space: nowrap;
+  }
 `
 
 export const BackButtonContainer = styled.div`

--- a/src/pages/Confirm/Confirm.styled.jsx
+++ b/src/pages/Confirm/Confirm.styled.jsx
@@ -39,6 +39,10 @@ export const CheckImg = styled.img`
     bottom: 0;
     width: 320px;
   }
+
+  @media screen and (min-width: 1025px) and (max-height: 800px) {
+    width: 40vh;
+  }
 `
 
 export const HeaderContainer = styled.div`
@@ -48,6 +52,10 @@ export const HeaderContainer = styled.div`
 
   @media (min-width: 1025px) {
     white-space: nowrap;
+  }
+
+  @media screen and (min-width: 1025px) and (max-height: 800px) {
+    margin: 5vh 5vw;
   }
 `
 

--- a/src/pages/Confirm/index.jsx
+++ b/src/pages/Confirm/index.jsx
@@ -113,7 +113,7 @@ const Confirm = () => {
       }
     >
       <>
-        <Text color="third" lg bold uppercase>
+        <Text color="blue" lg bold uppercase>
           Confirma recepción
         </Text>
         <Form onSubmit={e => submitConfirmation(e)} FormButtonSecondaryTitle ='Reportar'>


### PR DESCRIPTION
### Description

Increased width image notebook, updated title and subtitle color, size, and weight.

fixes #126 

#### Screenshots

![image (1)](https://user-images.githubusercontent.com/71513679/162786471-35f3a32b-88e8-4ca2-be02-cf404fe872dc.png)


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test it

Go to 'confirm/1'

### Checklist:

- [x] Doesn't break the current code.
- [ ] Passes linters and test, also is building.
- [ ] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.
